### PR TITLE
Hard coding the navigator document bucket prefix.

### DIFF
--- a/src/navigator_data_ingest/base/api_client.py
+++ b/src/navigator_data_ingest/base/api_client.py
@@ -158,7 +158,7 @@ def _store_document_in_cache(
     data: bytes,
 ) -> str:
     clean_name = name.lstrip("/")
-    output_file_location = S3Path(f"s3://{bucket}/{clean_name}")
+    output_file_location = S3Path(f"s3://{bucket}/navigator/{clean_name}")
     with output_file_location.open("wb") as output_file:
         output_file.write(data)
     return clean_name


### PR DESCRIPTION
Hard coding the navigator document bucket prefix as we have restructured the s3 prefix in s3. 