### PR TITLE
Updating field to be optional.

### DIFF
--- a/src/navigator_data_ingest/base/types.py
+++ b/src/navigator_data_ingest/base/types.py
@@ -191,8 +191,8 @@ class UnsupportedContentTypeError(Exception):
 class Update(BaseModel):
     """Class describing the results of comparing csv data against the db data to identify updates."""
 
+    s3_value: Optional[Union[str, datetime]]
     db_value: Union[str, datetime]
-    s3_value: Union[str, datetime]
     type: UpdateTypes
 
 


### PR DESCRIPTION
Updating field to be optional as this is now optional in the identify updates stage and thus new_and_updated_documents object. 