### PR TITLE
Adding functionality to handle source urls that have percents in them.

### DIFF
--- a/src/navigator_data_ingest/base/api_client.py
+++ b/src/navigator_data_ingest/base/api_client.py
@@ -140,6 +140,13 @@ def _download_from_source(
     session: requests.Session, source_url: str
 ) -> requests.Response:
     download_response = session.get(source_url, allow_redirects=True, timeout=5)
+
+    # TODO this is a hack and we should handle source urls upstream in the backend
+    if download_response.status_code == 404:
+        download_response_altered = session.get(source_url.replace("%", ""), allow_redirects=True, timeout=5)
+        if download_response_altered.status_code == 200:
+            download_response = download_response_altered
+
     if download_response.status_code >= 300:
         raise Exception(
             f"Downloading source document failed: {download_response.status_code} "


### PR DESCRIPTION
This issue was identified when running the pipeline over the documents during the ingest stage when the ingest attempts to download the documents from the download url (cached data location in s3)

The image below of testing the urls in console shows the issue: 

![image](https://github.com/climatepolicyradar/navigator-data-ingest/assets/58440325/a7bd59b6-86a2-47b6-97ec-0fabb91e2e0f)
