### PR TITLE
Bugfix in the ingest stage for pydantic errors on document source url. 

### DIFF
--- a/src/navigator_data_ingest/base/new_document_actions.py
+++ b/src/navigator_data_ingest/base/new_document_actions.py
@@ -109,6 +109,10 @@ def _handle_document(
     """
     Upload document source files & update details via API endpoint.
 
+    Function validates the source url in particular as in the ParserInput object we
+    require that this is a valid AnyHttpUrl. All the other fields are direct
+    translations from the BackendDocument object.
+
     :param Document document: A document to upload.
     """
     _LOGGER.info(f"Handling document: {document}")

--- a/src/navigator_data_ingest/base/new_document_actions.py
+++ b/src/navigator_data_ingest/base/new_document_actions.py
@@ -5,6 +5,7 @@ from typing import Generator, Iterable
 
 import requests
 from slugify import slugify
+import pydantic
 
 from navigator_data_ingest.base.api_client import upload_document
 from navigator_data_ingest.base.types import (
@@ -113,12 +114,32 @@ def _handle_document(
     _LOGGER.info(f"Handling document: {document}")
 
     session = requests.Session()
+
+    try:
+        document_source_url = (
+            pydantic.AnyHttpUrl(document.source_url) if document.source_url else None
+        )
+
+    except pydantic.ValidationError:
+        _LOGGER.exception(f"Ingesting document with ID '{document.import_id}' failed.")
+        return HandleResult(
+            error=traceback.format_exc(),
+            parser_input=ParserInput(
+                document_id=document.import_id,
+                document_slug=document.slug,
+                document_name=document.name,
+                document_description=document.description,
+                document_source_url=None,
+                document_metadata=document,
+            ),
+        )
+
     parser_input = ParserInput(
         document_id=document.import_id,
         document_slug=document.slug,
         document_name=document.name,
         document_description=document.description,
-        document_source_url=document.source_url,
+        document_source_url=document_source_url,
         document_metadata=document,
     )
 


### PR DESCRIPTION
This Pull Request: 
--- 
- Integrates a bug fix for catching pydantic validation errors in the ingest stage. 
- The function expects a ParserInput object in the response even on failure and thus constructing this without a document source url if validation fails. 
- Couldn't just move the try and except because of this. 
- I don't think we need to catch validation errors on the instantiation of the ParserInput object if the document source url passes as everything else is a direct type copy. E.g. import id [str] -> document import id [str]