### PR TITLE
handle .doc extensions as well as .docx

### DIFF
--- a/src/navigator_data_ingest/base/api_client.py
+++ b/src/navigator_data_ingest/base/api_client.py
@@ -18,6 +18,7 @@ from navigator_data_ingest.base.types import (
     SUPPORTED_CONTENT_TYPES,
     CONTENT_TYPE_DOCX,
     CONTENT_TYPE_PDF,
+    CONTENT_TYPE_DOC,
     UnsupportedContentTypeError,
     UploadResult,
 )
@@ -65,8 +66,8 @@ def upload_document(
         content_type = determine_content_type(download_response, source_url)
         file_content = download_response.content
 
-        # If the content type is DOCX, convert it to PDF
-        if content_type == CONTENT_TYPE_DOCX:
+        # If the content type is DOCX or DOC, convert it to PDF
+        if content_type in {CONTENT_TYPE_DOCX, CONTENT_TYPE_DOC}:
             content_type = CONTENT_TYPE_PDF
             file_content = convert_doc_to_pdf(file_content)
 

--- a/src/navigator_data_ingest/base/types.py
+++ b/src/navigator_data_ingest/base/types.py
@@ -11,14 +11,18 @@ from typing import (
 
 from cpr_sdk.parser_models import ParserInput
 from cpr_sdk.pipeline_general_models import (
-    CONTENT_TYPE_DOCX,
-    CONTENT_TYPE_HTML,
-    CONTENT_TYPE_PDF,
     BackendDocument,
     Update,
     UpdateTypes,
 )
 from pydantic import BaseModel
+
+CONTENT_TYPE_HTML = "text/html"
+CONTENT_TYPE_DOCX = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+CONTENT_TYPE_PDF = "application/pdf"
+CONTENT_TYPE_DOC = "application/msword"
 
 SINGLE_FILE_CONTENT_TYPES = {
     CONTENT_TYPE_PDF,
@@ -45,6 +49,7 @@ FILE_EXTENSION_MAPPING = {
     CONTENT_TYPE_PDF: ".pdf",
     CONTENT_TYPE_HTML: ".html",
     CONTENT_TYPE_DOCX: ".docx",
+    CONTENT_TYPE_DOC: ".doc",
 }
 # Reversed mapping to get content types from file extensions
 CONTENT_TYPE_MAPPING = {v: k for k, v in FILE_EXTENSION_MAPPING.items()}

--- a/src/navigator_data_ingest/base/utils.py
+++ b/src/navigator_data_ingest/base/utils.py
@@ -91,6 +91,10 @@ def determine_content_type(response: Response, source_url: str) -> str:
     """
 
     content_type_header = response.headers["Content-Type"].split(";")[0]
-    file_extension_start_index = source_url.rindex(".")
-    file_extension = source_url[file_extension_start_index:]
-    return CONTENT_TYPE_MAPPING.get(file_extension, content_type_header)
+    try:
+        file_extension_start_index = source_url.rindex(".")
+        file_extension = source_url[file_extension_start_index:]
+        return CONTENT_TYPE_MAPPING.get(file_extension, content_type_header)
+    except ValueError:
+        # Some URLs don't have a file extension, so use the content type header
+        return content_type_header

--- a/src/navigator_data_ingest/tests/conftest.py
+++ b/src/navigator_data_ingest/tests/conftest.py
@@ -307,3 +307,13 @@ def pdf_bytes():
     with open(pdf_data, "rb") as b:
         contents = b.read()
     return contents
+
+
+@pytest.fixture
+def doc_bytes():
+    """Bytes from a valid doc"""
+    fixture_dir = os.path.join(os.path.dirname(__file__), "fixtures")
+    doc_data = os.path.join(fixture_dir, "sample-for-word-to-pdf-conversion.doc")
+    with open(doc_data, "rb") as b:
+        contents = b.read()
+    return contents

--- a/src/navigator_data_ingest/tests/test_api_client.py
+++ b/src/navigator_data_ingest/tests/test_api_client.py
@@ -84,4 +84,4 @@ def test_upload_document__unreadable(
 
     assert result.md5_sum is None
     assert result.cdn_object is None
-    assert result.content_type is None
+    assert result.content_type == "text/html"


### PR DESCRIPTION
## In this PR

- Makes the ingest stage work for doc files (it only worked for docx before).
- Also intentionally separates out where we define content types from the SDK, which deals with parser outputs. (I think this is ok as once we start converting to PDF, we expect the list of content types we handle in ingest to be a superset of those we handle in the SDK – so we don't want to bump the SDK for each new content type we handle.)
- Driveby fix for another test that was failing locally - detecting content type for URLs which don't have a file extension in them (e.g. htmls). The behaviour now seems to reflect what _should_ happen; I'm not sure how this failing local test passed before!

## How this is tested

- Adds a test for doc and docx files in the upload files function
