### PR TITLE
content type of source should still be output if it's unsupported

### DIFF
--- a/src/navigator_data_ingest/base/api_client.py
+++ b/src/navigator_data_ingest/base/api_client.py
@@ -67,6 +67,7 @@ def upload_document(
         download_response = _download_from_source(session, source_url)
         content_type = determine_content_type(download_response, source_url)
         file_content = download_response.content
+        upload_result.content_type = content_type
 
         if content_type == CONTENT_TYPE_HTML:
             # If the content type is HTML, capture the PDF from the URL
@@ -86,8 +87,6 @@ def upload_document(
 
         else:
             raise UnsupportedContentTypeError(content_type)
-
-        upload_result.content_type = content_type
 
         # Calculate the m5sum & update the result object with the calculated value
         file_hash = hashlib.md5(file_content).hexdigest()

--- a/src/navigator_data_ingest/tests/test_api_client.py
+++ b/src/navigator_data_ingest/tests/test_api_client.py
@@ -67,3 +67,38 @@ def test_upload_document__readable(
     assert result.cdn_object is not None
     assert result.cdn_object.startswith("TEST/1970/test_slug")
     assert result.cdn_object.endswith(output_extension)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("url", "input_content_type"),
+    [
+        ("mock://somedata.octet", "binary/octet-stream"),
+        ("mock://somedata.zip", "application/zip"),
+    ],
+)
+def test_upload_document__unsupported_content_type(
+    test_s3_client__cdn,
+    mock_cdn_config,
+    requests_mock,
+    url,
+    input_content_type,
+):
+    session = requests.Session()
+
+    requests_mock.get(
+        url, content=b"mock content", headers={"content-type": input_content_type}
+    )
+
+    result = upload_document(
+        session=session,
+        source_url=url,
+        s3_prefix="TEST/1970",
+        file_name_without_suffix="test_slug",
+        document_bucket=mock_cdn_config["bucket"],
+        import_id="TEST.0.1",
+    )
+
+    assert result.content_type == input_content_type
+    assert result.cdn_object is None
+    assert result.md5_sum is None


### PR DESCRIPTION
Fix to resolve failing integration test in the pipeline [[1](https://github.com/climatepolicyradar/navigator-data-pipeline/actions/runs/14864381602/job/41737779885?pr=402)]

```
=========================== short test summary info ============================
FAILED IntegrationTests/test_pipeline.py::test_ingest_output - AssertionError: ('Test: ingest_output - Differing data for documents', "Documents: ['TESTCCLW.legislative.1014.1904']", "Errors: {'TESTCCLW.legislative.1014.1904': {'differing_keys_error': None, 'differing_values_errors': [{'test': 'ingest_output', 'key': 'document_content_type', 'expected': 'binary/octet-stream', 'actual': None}]}}")
```

