### PR TITLE
chore: Use latest Dependabot reviewers approach

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @climatepolicyradar/deng

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: cpr_sdk
-    reviewers:
-      - climatepolicyradar/deng
   - package-ecosystem: github-actions
     commit-message:
       prefix: feat
@@ -30,8 +28,6 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: cpr_sdk
-    reviewers:
-      - climatepolicyradar/deng
   - package-ecosystem: pip
     commit-message:
       prefix: feat
@@ -47,6 +43,4 @@ updates:
     allow: 
       - dependency-name: cpr_sdk
     target-branch: main
-    reviewers:
-       - climatepolicyradar/deng
 


### PR DESCRIPTION
`reviewers` has been deprecated, and Dependabot now uses the CODEOWNERS.
